### PR TITLE
feat(invoice): add city field to invoice provider on preview and create

### DIFF
--- a/source/includes/params/invoice.md.erb
+++ b/source/includes/params/invoice.md.erb
@@ -8,6 +8,7 @@
   "rut": "987654321",
   "phone": "56912345678",
   "contact_name": "Tulio Triviño",
+  "city": "Titirilquén",
   "charges": [
     {
       "name": "Servicio digital",
@@ -28,5 +29,6 @@
 | `rut`                  | **string**        | RUT del receptor de la factura de venta. No debe tener puntos ni guión.                             |
 | `phone`                | **string**        | Teléfono de contacto del receptor de la factura de venta.                                           |
 | `contact_name`         | **string**        | Nombre de contacto del receptor de la factura de venta.                                            |
+| `city`                 | **string**        | Ciudad del receptor de la factura de venta.                                            |
 | `charges`              | **array[Charge]** | Lista de cargos para cada producto. Ver [Charge](#definicion-de-objetos-charge)                                                |
 


### PR DESCRIPTION
Add optional city field for providers. This is useful in those case when SII does not autocomplete this field for some companies.